### PR TITLE
Constant-time version of `fq_cond_sub`

### DIFF
--- a/Reference_Implementation/include/fq_arith.h
+++ b/Reference_Implementation/include/fq_arith.h
@@ -124,8 +124,12 @@ FQ_ELEM fq_red(FQ_DOUBLEPREC x)
 
 static inline
 FQ_ELEM fq_cond_sub(const FQ_DOUBLEPREC x) {
-    // this is not constant-time!
-    return (x >= Q) ? (x - Q) : x;
+    // // this is not constant-time!
+    // return (x >= Q) ? (x - Q) : x;
+    // likely to be ~ constant-time (a "smart" compiler might turn this into conditionals though)
+    FQ_DOUBLEPREC sub_q = x - Q;
+    FQ_DOUBLEPREC mask = -((sub_q >> NUM_BITS_Q) & 1);
+    return (mask & Q) + sub_q;
 }
 
 static inline


### PR DESCRIPTION
This is a bit slower than the previous conditional implementation.
A preliminary benchmark shows ~ a 7% increase in Keygen time (CAT_3_BALANCED).
Note that it's possible that a "smart" compiler might still turn this into non-constant time instructions.