### PR TITLE
Fast modular reduction and F_q operations

### DIFF
--- a/Reference_Implementation/CMakeLists.txt
+++ b/Reference_Implementation/CMakeLists.txt
@@ -110,7 +110,8 @@ add_executable(bench_cf ${PROJECT_SOURCE_DIR}/lib/bench/bench_cf.c ${SOURCES})
 target_link_libraries(bench_cf PRIVATE OpenSSL::Crypto)
 set_property(TARGET bench_cf APPEND PROPERTY COMPILE_FLAGS "-DCATEGORY_1 -DBALANCED=1")
 
-add_executable(bench_rref ${PROJECT_SOURCE_DIR}/lib/bench/bench_rref.c ${SOURCES})
+add_executable(bench_rref ${CMAKE_CURRENT_SOURCE_DIR}/lib/test/test_helpers.c ${CMAKE_CURRENT_SOURCE_DIR}/lib/bench/bench_rref.c ${SOURCES})
+target_include_directories(bench_rref PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/test)
 target_link_libraries(bench_rref PRIVATE OpenSSL::Crypto)
 set_property(TARGET bench_rref APPEND PROPERTY COMPILE_FLAGS "-DCATEGORY_1 -DBALANCED=1")
 

--- a/Reference_Implementation/include/codes.h
+++ b/Reference_Implementation/include/codes.h
@@ -49,10 +49,6 @@ typedef struct {
 /* Calculate pivot flag array */
 void generator_get_pivot_flags (const rref_generator_mat_t *const G,
                                 uint8_t pivot_flag [N]);
-//
-void scale_row(generator_mat_t *G,
-               const uint32_t row,
-               const FQ_ELEM a);
 
 void column_swap(normalized_IS_t *V,
                  const POSITION_T col1,
@@ -176,12 +172,6 @@ void generator_rref_expand(generator_mat_t *full,
  * returns 1 on success, 0 on failure */
 int generator_gausselim(generator_mat_t *G);
 
-void apply_action_to_G(generator_mat_t* res,
-                       const generator_mat_t* G,
-                       const monomial_action_IS_t* Q_IS,
-                       uint8_t initial_G_col_pivot[N],
-                       uint8_t permutated_G_col_pivot[N]);
-
 //
 void apply_cf_action_to_G(generator_mat_t* res,
                           const generator_mat_t *G,
@@ -207,13 +197,9 @@ void normalized_copy(normalized_IS_t *V1, const normalized_IS_t *V2);
 void generator_SF_seed_expand(rref_generator_mat_t *res,
                               const unsigned char seed[SEED_LENGTH_BYTES]);
 
-void normalized_pretty_print_v(const FQ_ELEM values[K][N-K]);
 void generator_pretty_print(const generator_mat_t *const G);
 void generator_pretty_print_name(char *name, const generator_mat_t *const G);
 void generator_rref_pretty_print_name(char *name,
                                       const rref_generator_mat_t *const G);
 
 void normalized_pretty_print(const normalized_IS_t *const G);
-int normalized_is_zero_in_column(const normalized_IS_t *const V,
-                                 const uint32_t col);
-void normalized_mat_scale_row(normalized_IS_t *G, const uint32_t row, const FQ_ELEM a);

--- a/Reference_Implementation/include/fq_arith.h
+++ b/Reference_Implementation/include/fq_arith.h
@@ -123,12 +123,12 @@ FQ_ELEM fq_red(FQ_DOUBLEPREC x)
 
 
 static inline
-FQ_ELEM fq_cond_sub(const FQ_DOUBLEPREC x) {
+FQ_ELEM fq_cond_sub(const FQ_ELEM x) {
     // // this is not constant-time!
     // return (x >= Q) ? (x - Q) : x;
     // likely to be ~ constant-time (a "smart" compiler might turn this into conditionals though)
-    FQ_DOUBLEPREC sub_q = x - Q;
-    FQ_DOUBLEPREC mask = -((sub_q >> NUM_BITS_Q) & 1);
+    FQ_ELEM sub_q = x - Q;
+    FQ_ELEM mask = -(sub_q >> NUM_BITS_Q);
     return (mask & Q) + sub_q;
 }
 
@@ -148,7 +148,7 @@ FQ_ELEM fq_red_barrett(const FQ_DOUBLEPREC x) {
 
 static inline
 FQ_ELEM fq_red(const FQ_DOUBLEPREC x) {
-    return fq_cond_sub((x >> NUM_BITS_Q) + (x & 0x7f));
+    return fq_cond_sub((x >> NUM_BITS_Q) + ((FQ_ELEM) x & Q));
 }
 
 static inline

--- a/Reference_Implementation/include/fq_arith.h
+++ b/Reference_Implementation/include/fq_arith.h
@@ -124,8 +124,12 @@ FQ_ELEM fq_red(FQ_DOUBLEPREC x)
 
 static inline
 FQ_ELEM fq_cond_sub(const FQ_DOUBLEPREC x) {
-    // this is not constant-time!
-    return (x >= Q) ? (x - Q) : x;
+    // // this is not constant-time!
+    // return (x >= Q) ? (x - Q) : x;
+    // likely to be ~ constant-time (a "smart" compiler might turn this into conditionals though)
+    FQ_DOUBLEPREC sub_q = x - Q;
+    FQ_DOUBLEPREC mask = -((sub_q >> NUM_BITS_Q) & 1);
+    return (mask & Q) + sub_q;
 }
 
 static inline

--- a/Reference_Implementation/include/m1cycles.h
+++ b/Reference_Implementation/include/m1cycles.h
@@ -64,7 +64,7 @@ KPERF_LIST
 uint64_t g_counters[COUNTERS_COUNT];
 uint64_t g_config[COUNTERS_COUNT];
 
-static void configure_rdtsc()
+static void configure_rdtsc(void)
 {
     if (kpc_set_config(KPC_MASK, g_config))
     {

--- a/Reference_Implementation/include/monomial_mat.h
+++ b/Reference_Implementation/include/monomial_mat.h
@@ -88,10 +88,6 @@ void monomial_mat_mul(monomial_t *res,
 void monomial_mat_inv(monomial_t *res,
                       const monomial_t *const to_invert);
 
-/* samples a random monomial matrix from the systemwide csprng*/
-void monomial_mat_rnd(monomial_t *res);
-void monomial_mat_rnd_unique(monomial_t *res);
-
 /* expands a monomial matrix, given a PRNG seed and a salt (used for ephemeral
  * monomial matrices */
 void monomial_mat_seed_expand_salt_rnd(monomial_t *res,

--- a/Reference_Implementation/lib/bench/bench_rref.c
+++ b/Reference_Implementation/lib/bench/bench_rref.c
@@ -6,6 +6,7 @@
 #include "canonical.h"
 #include "cycles.h"
 #include "sort.h"
+#include "test_helpers.h"
 
 #define ITERS (1u << 10u)
 

--- a/Reference_Implementation/lib/bench/bench_sorting.c
+++ b/Reference_Implementation/lib/bench/bench_sorting.c
@@ -63,7 +63,7 @@ int bench_row_sorting(void) {
     for (uint64_t i = 0; i < ITERS; i++) {
         normalized_rng(&G1);
         c -= x86_64_rtdsc();
-        row_quick_sort(&G1);
+        row_quick_sort(&G1, N);
         c += x86_64_rtdsc();
     }
     c = c/ITERS;
@@ -92,7 +92,7 @@ int bench_col_sorting(void) {
         normalized_rng(&G1);
 
         c -= x86_64_rtdsc();
-        col_quicksort_transpose(&G1);
+        col_quicksort_transpose(&G1, K);
         c += x86_64_rtdsc();
     }
     c = c/ITERS;

--- a/Reference_Implementation/lib/monomial.c
+++ b/Reference_Implementation/lib/monomial.c
@@ -145,16 +145,16 @@ void monomial_mat_seed_expand_rnd(monomial_t *res,
     yt_shuffle_state(&shake_monomial_state, res->permutation);
 
 }
-
-/* samples a random perm matrix */
-void monomial_mat_rnd(monomial_t *res) {
-   fq_star_rnd_elements(res->coefficients, N);
-   for(uint32_t i = 0; i < N; i++) {
-      res->permutation[i] = i;
-   }
-   /* FY shuffle on the permutation */
-   yt_shuffle(res->permutation);
-} /* end monomial_mat_rnd */
+//
+// /* samples a random perm matrix */
+// void monomial_mat_rnd(monomial_t *res) {
+//    fq_star_rnd_elements(res->coefficients, N);
+//    for(uint32_t i = 0; i < N; i++) {
+//       res->permutation[i] = i;
+//    }
+//    /* FY shuffle on the permutation */
+//    yt_shuffle(res->permutation);
+// } /* end monomial_mat_rnd */
 
 /// \param res[out] = to_invert**-1
 /// \param to_invert[in]

--- a/Reference_Implementation/lib/monomial.c
+++ b/Reference_Implementation/lib/monomial.c
@@ -146,6 +146,16 @@ void monomial_mat_seed_expand_rnd(monomial_t *res,
 
 }
 
+/* samples a random perm matrix */
+void monomial_mat_rnd(monomial_t *res) {
+   fq_star_rnd_elements(res->coefficients, N);
+   for(uint32_t i = 0; i < N; i++) {
+      res->permutation[i] = i;
+   }
+   /* FY shuffle on the permutation */
+   yt_shuffle(res->permutation);
+} /* end monomial_mat_rnd */
+
 /// \param res[out] = to_invert**-1
 /// \param to_invert[in]
 void monomial_mat_inv(monomial_t *res,

--- a/Reference_Implementation/lib/test/test_helpers.c
+++ b/Reference_Implementation/lib/test/test_helpers.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdio.h>
 #include "fq_arith.h"
 #include "LESS.h"
 #include "codes.h"

--- a/Reference_Implementation/lib/test/test_helpers.h
+++ b/Reference_Implementation/lib/test/test_helpers.h
@@ -1,0 +1,9 @@
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#include "monomial_mat.h"
+
+void monomial_mat_rnd(monomial_t *res);
+void monomial_mat_rnd_unique(monomial_t *res);
+
+#endif //TEST_HELPERS_H


### PR DESCRIPTION
Faster modular reduction for Q=127 and faster F_q subtraction.

CAT_3_BALANCED balanced on Apple M1 shows > 20x speed-up.

|             | **keygen** |   **sign**   |  **verify**  |
|-------------|:----------:|:------------:|:------------:|
| **Prev**    | 106,655.59 | 7,756,485.19 | 7,725,509.79 |
| **This PR** |   4,647.83 |   788,391.86 |   763,455.55 |
| **Speedup** |        23x |          10x |          10x |